### PR TITLE
Trying to use nexus-staging-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,12 @@
   <ciManagement />
   <distributionManagement>
     <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
+      <id>cloudbees-nexus-snapshots</id>
       <name>Sonatype Nexus Snapshots</name>
       <url>${sonatypeOssDistMgmtSnapshotsUrl}</url>
     </snapshotRepository>
     <repository>
-      <id>sonatype-nexus-staging</id>
+      <id>cloudbees-nexus-staging</id>
       <name>Nexus Release Repository</name>
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
@@ -72,7 +72,7 @@
 
   <repositories>
     <repository>
-      <id>sonatype-nexus-snapshots</id>
+      <id>cloudbees-nexus-snapshots</id>
       <name>Sonatype Nexus Snapshots</name>
       <url>${sonatypeOssDistMgmtSnapshotsUrl}</url>
       <releases>

--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,12 @@
   <ciManagement />
   <distributionManagement>
     <snapshotRepository>
-      <id>cloudbees-nexus-snapshots</id>
+      <id>sonatype-nexus-snapshots</id>
       <name>Sonatype Nexus Snapshots</name>
       <url>${sonatypeOssDistMgmtSnapshotsUrl}</url>
     </snapshotRepository>
     <repository>
-      <id>cloudbees-nexus-staging</id>
+      <id>sonatype-nexus-staging</id>
       <name>Nexus Release Repository</name>
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
@@ -72,9 +72,9 @@
 
   <repositories>
     <repository>
-      <id>cloudbees-nexus-snapshots</id>
+      <id>sonatype-nexus-snapshots</id>
       <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>${sonatypeOssDistMgmtSnapshotsUrl}</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -119,6 +119,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.5</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>sonatype-nexus-staging</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -151,6 +162,7 @@
           <version>2.5.1</version>
           <configuration>
             <mavenExecutorId>forked-path</mavenExecutorId>
+            <!-- TODO is there something wrong with the standard release profile, other than not including maven-gpg-plugin? -->
             <useReleaseProfile>false</useReleaseProfile>
             <arguments>-P+cloudbees-oss-release ${arguments}</arguments>
           </configuration>


### PR DESCRIPTION
Found to my annoyance that releasing https://github.com/cloudbees/groovy-cps/commit/6c21a4465dd07a7d6b750f4d8e515deede1888a9 did not work immediately; I need to go into the [web UI](https://oss.sonatype.org/#stagingRepositories). Trying to make this work by analogy with [kohsuke/pom](https://github.com/kohsuke/pom/blob/564fb2ccf3f89281963f58329788183691af872f/pom.xml#L67-76). Also see [this](http://books.sonatype.com/nexus-book/reference/staging-deployment.html) and [this](http://central.sonatype.org/pages/apache-maven.html#nexus-staging-maven-plugin-for-deployment-and-release). @reviewbybees but esp. @stephenc and @kohsuke
