### PR TITLE
[chore] Update to using the central Portal OSSRH Staging API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <repository>
       <id>cloudbees-nexus-staging</id>
       <name>Nexus Release Repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>${distributionRootUrl}/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
 
@@ -70,7 +70,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/
+    <distributionRootUrl>https://ossrh-staging-api.central.sonatype.com</distributionRootUrl>
+    <sonatypeOssDistMgmtSnapshotsUrl>${distributionRootUrl}/content/repositories/snapshots/
     </sonatypeOssDistMgmtSnapshotsUrl>
     <git.provider>git</git.provider>
     <maven-scm.version>1.9.4</maven-scm.version>
@@ -234,7 +235,7 @@
         <extensions>true</extensions>
         <configuration>
           <serverId>cloudbees-nexus-snapshots</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <nexusUrl>${distributionRootUrl}/</nexusUrl>
           <autoReleaseAfterClose>true</autoReleaseAfterClose>
           <!--stagingProfileId>2ba52c484c574d</stagingProfileId--><!-- if groupId starts with com.cloudbees-->
           <!--stagingProfileId>2acf39d998ccd7</stagingProfileId--><!-- if groupId starts with org.cloudbees-->


### PR DESCRIPTION
Publication to oss.sonatype.org is not possible anymore: https://central.sonatype.org/pages/ossrh-eol/#process-to-migrate

There are two (non mutually exclusive) options:
* use the bridge created to help the migration to central: https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/
* (longer term): switch to using the Maven central portal directly

This PR implements 1 and was validated by cutting a new release of [the zendesk-java-client](https://github.com/cloudbees-oss/zendesk-java-client)